### PR TITLE
Updates for latest imgui release

### DIFF
--- a/ImGuiFD.cpp
+++ b/ImGuiFD.cpp
@@ -1,6 +1,5 @@
 #include "ImGuiFD.h"
 #include "ImGuiFD_internal.h"
-#include "imgui.h"
 
 #include <string.h>
 

--- a/ImGuiFD.cpp
+++ b/ImGuiFD.cpp
@@ -1,5 +1,6 @@
 #include "ImGuiFD.h"
 #include "ImGuiFD_internal.h"
+#include "imgui.h"
 
 #include <string.h>
 
@@ -822,7 +823,7 @@ namespace ImGuiFD {
 
 		ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, { 0,0 });
 		while (s < text + len && lineInd < maxLines) {
-			const char* wrap = g.Font->CalcWordWrapPositionA(g.FontSize/g.Font->FontSize, s, text+len, maxWidth);
+			const char* wrap = g.Font->CalcWordWrapPositionA(g.FontBakedScale, s, text+len, maxWidth);
 			
 			ImVec2 lineSize;
 			if (wrap == s || lineInd+1 == maxLines) {
@@ -1202,7 +1203,7 @@ namespace ImGuiFD {
 		ImGui::TableNextRow();
 		ImGui::TableNextColumn();
 		bool isSel = fd->selected.contains(ind);
-		ImGuiSelectableFlags flags = ImGuiSelectableFlags_AllowItemOverlap | ImGuiSelectableFlags_SpanAllColumns;
+		ImGuiSelectableFlags flags = ImGuiSelectableFlags_AllowOverlap | ImGuiSelectableFlags_SpanAllColumns;
 
 		if (ImGui::Selectable(entry.isFolder?"[DIR]":"[FILE]", isSel, flags)) {
 			ClickedOnEntrySelect(ind, isSel, entry.isFolder);
@@ -1534,6 +1535,7 @@ namespace ImGuiFD {
 						}
 
 						ImGui::SetCursorPos(cursorEnd);
+            ImGui::Dummy(ImVec2(0,0));
 
 						//ImGuiWindow* window = ImGui::GetCurrentWindow();
 						//ImVec2 off = { window->Pos.x - window->Scroll.x, window->Pos.y - window->Scroll.y };


### PR DESCRIPTION
A few breaking changes have occurred with imgui in the last year, meaning this library doesn't compile anymore. This addresses changes to the fonts API, a change to the selectable flags, and an error/warning about needing a call to ImGui::Dummy after a call to SetCursorPos. 